### PR TITLE
Récupération de toutes les communes en une requête

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,10 +42,6 @@ app.get('/communes', initLimit(), initCommuneFields, initCommuneFormat, (req, re
   }
   if (query.nom) req.fields.add('_score')
 
-  if (Object.keys(query).length === 0) {
-    return res.sendStatus(400)
-  }
-
   const result = req.applyLimit(dbCommunes.search(query))
 
   if (req.outputFormat === 'geojson') {


### PR DESCRIPTION
Bonjour,

A priori, il n'est actuellement pas possible de récupérer toutes les communes en une seule requête. Cela fonctionne pour les départements et les régions mais non pour les communes. En gros, j'aimerais récupérer directement https://geo.api.gouv.fr/communes.

Cette limitation provient de [cette condition](https://github.com/etalab/api-communes/blob/master/server.js#L45). Est-ce possible de l'enlever pour que toutes les communes puissent être récupérées ?

Merci et bonne journée